### PR TITLE
Changes that makes sure jQuery is run on page reload.

### DIFF
--- a/js/ems.js
+++ b/js/ems.js
@@ -2,7 +2,7 @@
 Gets TEI for a song collection.
  */
 
-jQuery(document).ready(function(){
+jQuery(window).load(function(){
 	// Immediately replace to avoid showing the XML
 	var viewerDiv = jQuery(".islandora-simple-xml-content").first();
 	viewerDiv.empty().append('<div id="ems_viewer">EMS Custom Visuals</div>');


### PR DESCRIPTION
To test, clear the Drupal cache.  EMS.js should load similarly both when navigating to the page through the Drupal UI and when reloading/refreshing the page for an object.