### PR TITLE
Uses the canonical form of the origin for the path to bundle.js.

### DIFF
--- a/js/ems.js
+++ b/js/ems.js
@@ -28,9 +28,9 @@ jQuery(window).load(function(){
 			var titleInfo = "Title from TEI " + title;
 
 			viewerDiv.empty().append('<div id="ems_viewer" data-song="' + object_pid + '">' + titleInfo + '</div>');
+      var bundlePath = location.origin + '/sites/all/modules/ems/js/bundle.js';
+			jQuery.loadScript(bundlePath, function(){
 
-			jQuery.loadScript('http://localhost:8000/sites/all/modules/ems/js/bundle.js', function(){
-				alert('bundle.js loaded');
 			});
 		}
 	});


### PR DESCRIPTION
Uses location.origin to construct the path used for loading bundle.js.   This will allow the EMS module to load ems viewer both on a local development site and also on other sites like production. 